### PR TITLE
replace_ranges: Handle RFS exceptions

### DIFF
--- a/vstools/enums/other.py
+++ b/vstools/enums/other.py
@@ -166,6 +166,17 @@ class Resolution(NamedTuple):
     width: int
     height: int
 
+    @classmethod
+    def from_video(cls, clip: vs.VideoNode):
+        from ..functions import check_variable_resolution
+
+        assert check_variable_resolution(clip, cls.from_video)
+
+        return Resolution(clip.width, clip.height)
+
+    def __str__(self) -> str:
+        return f'{self.width}x{self.height}'
+
 
 class Coordinate:
     """

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -174,6 +174,11 @@ class MismatchError(CustomValueError):
     ) -> None:
         super().__init__(message, func, reason, **kwargs, reduced_items=iter(self._reduce(items)))
 
+    @classmethod
+    def check(cls, func: FuncExceptT, *items: T, **kwargs: Any) -> None:
+        if len(cls._reduce(items)) != 1:
+            raise cls(func, items, **kwargs)
+
 
 class FormatsMismatchError(MismatchError):
     """Raised when clips with different formats are given."""
@@ -190,6 +195,13 @@ class FormatsMismatchError(MismatchError):
     ) -> None:
         super().__init__(func, formats, message, **kwargs)
 
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, *formats: VideoFormatT | HoldsVideoFormatT, **kwargs: Any
+        ) -> None:
+            ...
+
 
 class FormatsRefClipMismatchError(FormatsMismatchError):
     """Raised when a ref clip and the main clip have different formats"""
@@ -199,6 +211,14 @@ class FormatsRefClipMismatchError(FormatsMismatchError):
         message: SupportsString = 'The format of ref and main clip must be equal!', **kwargs: Any
     ) -> None:
         super().__init__(func, [clip, ref], message, **kwargs)
+
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, clip: VideoFormatT | HoldsVideoFormatT,
+            ref: VideoFormatT | HoldsVideoFormatT, /, **kwargs: Any
+        ) -> None:
+            ...
 
 
 class ResolutionsMismatchError(MismatchError):
@@ -216,6 +236,13 @@ class ResolutionsMismatchError(MismatchError):
     ) -> None:
         super().__init__(func, resolutions, message, **kwargs)
 
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, *resolutions: Resolution | vs.VideoNode, **kwargs: Any
+        ) -> None:
+            ...
+
 
 class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have different resolutions"""
@@ -226,6 +253,13 @@ class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
     ) -> None:
         super().__init__(func, [clip, ref], message, **kwargs)
 
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, clip: Resolution | vs.VideoNode, ref: Resolution | vs.VideoNode, /, **kwargs: Any
+        ) -> None:
+            ...
+
 
 class LengthMismatchError(MismatchError):
     """Raised when clips with a different number of total frames are given."""
@@ -235,10 +269,17 @@ class LengthMismatchError(MismatchError):
         return str(int(item.num_frames if isinstance(item, vs.RawNode) else item))  # type: ignore
 
     def __init__(
-        self, func: FuncExceptT, clips: Iterable[int | vs.RawNode],
+        self, func: FuncExceptT, lengths: Iterable[int | vs.RawNode],
         message: SupportsString = 'All the lenghts must be equal!', **kwargs: Any
     ) -> None:
-        super().__init__(func, clips, message, **kwargs)
+        super().__init__(func, lengths, message, **kwargs)
+
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, *lengths: int | vs.RawNode, **kwargs: Any
+        ) -> None:
+            ...
 
 
 class LengthRefClipMismatchError(LengthMismatchError):
@@ -250,6 +291,13 @@ class LengthRefClipMismatchError(LengthMismatchError):
         **kwargs: Any
     ) -> None:
         super().__init__(func, [clip, ref], message, **kwargs)
+
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, clip: int | vs.RawNode, ref: int | vs.RawNode, /, **kwargs: Any
+        ) -> None:
+            ...
 
 
 class FramerateMismatchError(MismatchError):
@@ -267,6 +315,12 @@ class FramerateMismatchError(MismatchError):
     ) -> None:
         super().__init__(func, framerates, message, **kwargs)
 
+    if TYPE_CHECKING:
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, *framerates: vs.VideoNode | Fraction | tuple[int, int] | float, **kwargs: Any
+        ) -> None:
+            ...
+
 
 class FramerateRefClipMismatchError(FramerateMismatchError):
     """Raised when a ref clip and the main clip have a different framerate"""
@@ -279,6 +333,15 @@ class FramerateRefClipMismatchError(FramerateMismatchError):
         **kwargs: Any
     ) -> None:
         super().__init__(func, [clip, ref], message, **kwargs)
+
+    if TYPE_CHECKING:
+        @classmethod
+        def check(  # type: ignore[override]
+            cls, func: FuncExceptT, clip: vs.VideoNode | Fraction | tuple[int, int] | float,
+            ref: vs.VideoNode | Fraction | tuple[int, int] | float, /, **kwargs: Any
+        ) -> None:
+
+            ...
 
 
 class FramePropError(CustomKeyError):

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -161,7 +161,7 @@ class FormatsMismatchError(MismatchError):
     """Raised when clips with different formats are given."""
 
     def __init__(
-        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip_a: vs.RawNode, clip_b: vs.RawNode,
         message: SupportsString = 'The format of both clips must be equal!',
         reason: Any = '{a_format} != {b_format}',
         **kwargs: Any
@@ -175,7 +175,7 @@ class FormatsRefClipMismatchError(FormatsMismatchError):
     """Raised when a ref clip and the main clip have different formats"""
 
     def __init__(
-        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip: vs.RawNode, ref: vs.RawNode,
         message: SupportsString = 'The format of ref and main clip must be equal!',
         reason: Any = '{clip_format} != {ref_format}',
         **kwargs: Any
@@ -189,7 +189,7 @@ class ResolutionsMismatchError(MismatchError):
     """Raised when clips with different resolutions are given."""
 
     def __init__(
-        self, clip_a: vs.VideoNode, clip_b: vs.VideoNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip_a: vs.VideoNode, clip_b: vs.VideoNode,
         message: SupportsString = 'The resolution of both clips must be equal!',
         reason: Any = '{a_width}x{a_height} != {b_width}x{b_height}',
         **kwargs: Any
@@ -204,7 +204,7 @@ class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have different resolutions"""
 
     def __init__(
-        self, clip: vs.VideoNode, ref: vs.VideoNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip: vs.VideoNode, ref: vs.VideoNode,
         message: SupportsString = 'The resolution of ref and main clip must be equal!',
         reason: Any = '{clip_width}x{clip_height} != {ref_width}x{ref_height}',
         **kwargs: Any
@@ -219,7 +219,7 @@ class LengthMismatchError(MismatchError):
     """Raised when clips with a different number of total frames are given."""
 
     def __init__(
-        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip_a: vs.RawNode, clip_b: vs.RawNode,
         message: SupportsString = 'The amount of frames for every clip must be equal!',
         reason: Any = '{a_num_frames} != {b_num_frames}',
         **kwargs: Any
@@ -233,7 +233,7 @@ class LengthRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have a different number of total frames."""
 
     def __init__(
-        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip: vs.RawNode, ref: vs.RawNode,
         message: SupportsString = 'The amount of frames for the ref and main clip must be equal!',
         reason: Any = '{clip_num_frames} != {ref_num_frames}',
         **kwargs: Any
@@ -247,21 +247,19 @@ class FramerateMismatchError(MismatchError):
     """Raised when clips with a different framerate are given."""
 
     def __init__(
-        self, clip_a: vs.VideoNode, clip_b: vs.VideoNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip_a: vs.VideoNode, clip_b: vs.VideoNode,
         message: SupportsString = 'The framerate of every clip must be equal!',
         reason: Any = '{a_fps} != {b_fps}',
         **kwargs: Any
     ) -> None:
-        super().__init__(
-            message, func, reason, a_fps=clip_a.fps, b_fps=clip_b.fps, **kwargs
-        )
+        super().__init__(message, func, reason, a_fps=clip_a.fps, b_fps=clip_b.fps, **kwargs)
 
 
 class FramerateRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have a different framerate"""
 
     def __init__(
-        self, clip: vs.VideoNode, ref: vs.VideoNode, func: FuncExceptT,
+        self, func: FuncExceptT, clip: vs.VideoNode, ref: vs.VideoNode,
         message: SupportsString = 'The framerate of the ref and main clip must be equal!',
         reason: Any = '{clip_fps} != {ref_fps}',
         **kwargs: Any

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -167,7 +167,7 @@ class FormatsMismatchError(MismatchError):
         **kwargs: Any
     ) -> None:
         super().__init__(
-            message, func, reason, a_format=clip_a.format, b_format=clip_b.format, **kwargs
+            message, func, reason, a_format=clip_a.format.name, b_format=clip_b.format.name, **kwargs
         )
 
 
@@ -181,7 +181,7 @@ class FormatsRefClipMismatchError(FormatsMismatchError):
         **kwargs: Any
     ) -> None:
         super().__init__(
-            message, func, reason, clip_format=clip.format, ref_format=ref.format, **kwargs
+            message, func, reason, clip_format=clip.format.name, ref_format=ref.format.name, **kwargs
         )
 
 
@@ -189,7 +189,7 @@ class ResolutionsMismatchError(MismatchError):
     """Raised when clips with different resolutions are given."""
 
     def __init__(
-        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        self, clip_a: vs.VideoNode, clip_b: vs.VideoNode, func: FuncExceptT,
         message: SupportsString = 'The resolution of both clips must be equal!',
         reason: Any = '{a_width}x{a_height} != {b_width}x{b_height}',
         **kwargs: Any
@@ -204,7 +204,7 @@ class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have different resolutions"""
 
     def __init__(
-        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        self, clip: vs.VideoNode, ref: vs.VideoNode, func: FuncExceptT,
         message: SupportsString = 'The resolution of ref and main clip must be equal!',
         reason: Any = '{clip_width}x{clip_height} != {ref_width}x{ref_height}',
         **kwargs: Any
@@ -247,13 +247,13 @@ class FramerateMismatchError(MismatchError):
     """Raised when clips with a different framerate are given."""
 
     def __init__(
-        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        self, clip_a: vs.VideoNode, clip_b: vs.VideoNode, func: FuncExceptT,
         message: SupportsString = 'The framerate of every clip must be equal!',
         reason: Any = '{a_fps} != {b_fps}',
         **kwargs: Any
     ) -> None:
         super().__init__(
-            message, func, reason, a_num_frames=clip_a.fps, b_num_frames=clip_b.fps, **kwargs
+            message, func, reason, a_fps=clip_a.fps, b_fps=clip_b.fps, **kwargs
         )
 
 
@@ -261,13 +261,13 @@ class FramerateRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have a different framerate"""
 
     def __init__(
-        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        self, clip: vs.VideoNode, ref: vs.VideoNode, func: FuncExceptT,
         message: SupportsString = 'The framerate of the ref and main clip must be equal!',
         reason: Any = '{clip_fps} != {ref_fps}',
         **kwargs: Any
     ) -> None:
         super().__init__(
-            message, func, reason, a_num_frames=clip.fps, b_num_frames=ref.fps, **kwargs
+            message, func, reason, clip_fps=clip.fps, ref_fps=ref.fps, **kwargs
         )
 
 

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -17,6 +17,10 @@ __all__ = [
 
     'ResolutionsMismatchError', 'ResolutionsRefClipMismatchError',
 
+    'LengthMismatchError', 'LengthRefClipMismatchError',
+
+    'FramerateMismatchError', 'FramerateRefClipMismatchError',
+
     'InvalidVideoFormatError',
     'InvalidColorFamilyError',
     'InvalidSubsamplingError',
@@ -184,6 +188,46 @@ class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
 
     def __init__(
         self, func: FuncExceptT, message: SupportsString = 'The resolution of ref and main clip must be equal!',
+        **kwargs: Any
+    ) -> None:
+        super().__init__(func, message, **kwargs)
+
+
+class LengthMismatchError(CustomValueError):
+    """Raised when clips with a different number of total frames are given."""
+
+    def __init__(
+        self, func: FuncExceptT, message: SupportsString = 'The total frames of every clip must be equal!',
+        **kwargs: Any
+    ) -> None:
+        super().__init__(message, func, **kwargs)
+
+
+class LengthRefClipMismatchError(ResolutionsMismatchError):
+    """Raised when a ref clip and the main clip have a different number of total frames."""
+
+    def __init__(
+        self, func: FuncExceptT, message: SupportsString = 'The total frames of the ref and main clip must be equal!',
+        **kwargs: Any
+    ) -> None:
+        super().__init__(func, message, **kwargs)
+
+
+class FramerateMismatchError(CustomValueError):
+    """Raised when clips with a different framerate are given."""
+
+    def __init__(
+        self, func: FuncExceptT, message: SupportsString = 'The framerate of every clip must be equal!',
+        **kwargs: Any
+    ) -> None:
+        super().__init__(message, func, **kwargs)
+
+
+class FramerateRefClipMismatchError(ResolutionsMismatchError):
+    """Raised when a ref clip and the main clip have a different framerate"""
+
+    def __init__(
+        self, func: FuncExceptT, message: SupportsString = 'The framerate of the ref and main clip must be equal!',
         **kwargs: Any
     ) -> None:
         super().__init__(func, message, **kwargs)

--- a/vstools/exceptions/generic.py
+++ b/vstools/exceptions/generic.py
@@ -153,84 +153,122 @@ class InvalidSubsamplingError(CustomValueError):
         super().__init__(message, func, subsampling=subsampling, **kwargs)
 
 
-class FormatsMismatchError(CustomValueError):
+class MismatchError(CustomValueError):
+    """Raised when there's a mismatch between two or more values."""
+
+
+class FormatsMismatchError(MismatchError):
     """Raised when clips with different formats are given."""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The format of both clips must be equal!',
+        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The format of both clips must be equal!',
+        reason: Any = '{a_format} != {b_format}',
         **kwargs: Any
     ) -> None:
-        super().__init__(message, func, **kwargs)
+        super().__init__(
+            message, func, reason, a_format=clip_a.format, b_format=clip_b.format, **kwargs
+        )
 
 
 class FormatsRefClipMismatchError(FormatsMismatchError):
     """Raised when a ref clip and the main clip have different formats"""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The format of ref and main clip must be equal!',
+        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The format of ref and main clip must be equal!',
+        reason: Any = '{clip_format} != {ref_format}',
         **kwargs: Any
     ) -> None:
-        super().__init__(func, message, **kwargs)
+        super().__init__(
+            message, func, reason, clip_format=clip.format, ref_format=ref.format, **kwargs
+        )
 
 
-class ResolutionsMismatchError(CustomValueError):
+class ResolutionsMismatchError(MismatchError):
     """Raised when clips with different resolutions are given."""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The resolution of both clips must be equal!',
+        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The resolution of both clips must be equal!',
+        reason: Any = '{a_width}x{a_height} != {b_width}x{b_height}',
         **kwargs: Any
     ) -> None:
-        super().__init__(message, func, **kwargs)
+        super().__init__(
+            message, func, reason, a_width=clip_a.width, a_height=clip_a.height,
+            b_width=clip_b.width, b_height=clip_b.height, **kwargs
+        )
 
 
 class ResolutionsRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have different resolutions"""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The resolution of ref and main clip must be equal!',
+        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The resolution of ref and main clip must be equal!',
+        reason: Any = '{clip_width}x{clip_height} != {ref_width}x{ref_height}',
         **kwargs: Any
     ) -> None:
-        super().__init__(func, message, **kwargs)
+        super().__init__(
+            message, func, reason, clip_width=clip.width, clip_height=clip.height,
+            ref_width=ref.width, ref_height=ref.height, **kwargs
+        )
 
 
-class LengthMismatchError(CustomValueError):
+class LengthMismatchError(MismatchError):
     """Raised when clips with a different number of total frames are given."""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The total frames of every clip must be equal!',
+        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The amount of frames for every clip must be equal!',
+        reason: Any = '{a_num_frames} != {b_num_frames}',
         **kwargs: Any
     ) -> None:
-        super().__init__(message, func, **kwargs)
+        super().__init__(
+            message, func, reason, a_num_frames=clip_a.num_frames, b_num_frames=clip_b.num_frames, **kwargs
+        )
 
 
 class LengthRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have a different number of total frames."""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The total frames of the ref and main clip must be equal!',
+        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The amount of frames for the ref and main clip must be equal!',
+        reason: Any = '{clip_num_frames} != {ref_num_frames}',
         **kwargs: Any
     ) -> None:
-        super().__init__(func, message, **kwargs)
+        super().__init__(
+            message, func, reason, clip_num_frames=clip.num_frames, ref_num_frames=ref.num_frames, **kwargs
+        )
 
 
-class FramerateMismatchError(CustomValueError):
+class FramerateMismatchError(MismatchError):
     """Raised when clips with a different framerate are given."""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The framerate of every clip must be equal!',
+        self, clip_a: vs.RawNode, clip_b: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The framerate of every clip must be equal!',
+        reason: Any = '{a_fps} != {b_fps}',
         **kwargs: Any
     ) -> None:
-        super().__init__(message, func, **kwargs)
+        super().__init__(
+            message, func, reason, a_num_frames=clip_a.fps, b_num_frames=clip_b.fps, **kwargs
+        )
 
 
 class FramerateRefClipMismatchError(ResolutionsMismatchError):
     """Raised when a ref clip and the main clip have a different framerate"""
 
     def __init__(
-        self, func: FuncExceptT, message: SupportsString = 'The framerate of the ref and main clip must be equal!',
+        self, clip: vs.RawNode, ref: vs.RawNode, func: FuncExceptT,
+        message: SupportsString = 'The framerate of the ref and main clip must be equal!',
+        reason: Any = '{clip_fps} != {ref_fps}',
         **kwargs: Any
     ) -> None:
-        super().__init__(func, message, **kwargs)
+        super().__init__(
+            message, func, reason, a_num_frames=clip.fps, b_num_frames=ref.fps, **kwargs
+        )
 
 
 class FramePropError(CustomKeyError):

--- a/vstools/functions/check.py
+++ b/vstools/functions/check.py
@@ -115,7 +115,8 @@ def check_ref_clip(src: vs.VideoNode, ref: vs.VideoNode | None, func: FuncExcept
     :param ref:     Reference clip.
                     Default: None.
 
-    :raises AssertionError:                     The format of either clip is None.
+    :raises VariableFormatError                 The format of either clip is variable.
+    :raises VariableResolutionError:            The resolution of either clip is variable.
     :raises FormatsRefClipMismatchError:        The formats of the two clips do not match.
     :raises ResolutionsRefClipMismatchError:    The resolutions of the two clips do not match.
     """
@@ -130,11 +131,8 @@ def check_ref_clip(src: vs.VideoNode, ref: vs.VideoNode | None, func: FuncExcept
     assert check_variable(src, func)  # type: ignore
     assert check_variable(ref, func)  # type: ignore
 
-    if ref.format.id != src.format.id:
-        raise FormatsRefClipMismatchError(func)  # type: ignore
-
-    if ref.width != src.width or ref.height != src.height:
-        raise ResolutionsRefClipMismatchError(func)  # type: ignore
+    FormatsRefClipMismatchError.check(func, src, ref)  # type: ignore
+    ResolutionsRefClipMismatchError.check(func, src, ref)  # type: ignore
 
 
 def check_variable_format(clip: vs.VideoNode, func: FuncExceptT) -> TypeGuard[ConstantFormatVideoNode]:

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -97,8 +97,6 @@ def replace_ranges(
                     raise FormatsMismatchError(replace_ranges, clip_a, clip_b)
                 case "Clip frame rates don't match":
                     raise FramerateMismatchError(replace_ranges, clip_a, clip_b)
-                case "Failed to open the timecodes file.":
-                    raise FileNotExistsError(msg, replace_ranges)
                 case _:
                     raise CustomValueError(msg, replace_ranges)
 

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -102,8 +102,9 @@ def replace_ranges(
 
     if clip_a.num_frames != clip_b.num_frames:
         warnings.warn(
-            f"replace_ranges: 'The number of frames ({clip_a.num_frames} vs. {clip_b.num_frames}) do not match! "
-            "The function will still work, but you may run into unintended errors with the output clip!'"
+            f"replace_ranges: 'The number of frames of the clips don't match! "
+            f"({clip_a.num_frames=}, {clip_b.num_frames=})\n"
+            "The function will still work, but you may run into undefined behavior, or a broken output clip!'"
         )
 
     out = clip_a

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -7,8 +7,8 @@ from typing import Iterable, overload
 import vapoursynth as vs
 
 from ..exceptions import (
-    CustomIndexError, FileNotExistsError, FormatsMismatchError, FramerateMismatchError, LengthMismatchError,
-    ResolutionsMismatchError
+    CustomIndexError, CustomValueError, FileNotExistsError, FormatsMismatchError, FramerateMismatchError,
+    LengthMismatchError, ResolutionsMismatchError
 )
 from ..functions import check_ref_clip
 from ..types import T0, FrameRangeN, FrameRangesN, T
@@ -90,15 +90,17 @@ def replace_ranges(
 
             match msg:
                 case "Clip lengths don't match":
-                    raise LengthMismatchError(clip_a, clip_b, replace_ranges)
+                    raise LengthMismatchError(replace_ranges, clip_a, clip_b)
                 case "Clip dimensions don't match":
-                    raise ResolutionsMismatchError(clip_a, clip_b, replace_ranges)
+                    raise ResolutionsMismatchError(replace_ranges, clip_a, clip_b)
                 case "Clip formats don't match":
-                    raise FormatsMismatchError(clip_a, clip_b, replace_ranges)
+                    raise FormatsMismatchError(replace_ranges, clip_a, clip_b)
                 case "Clip frame rates don't match":
-                    raise FramerateMismatchError(clip_a, clip_b, replace_ranges)
+                    raise FramerateMismatchError(replace_ranges, clip_a, clip_b)
                 case "Failed to open the timecodes file.":
                     raise FileNotExistsError(msg, replace_ranges)
+                case _:
+                    raise CustomValueError(msg, replace_ranges)
 
     if clip_a.num_frames != clip_b.num_frames:
         warnings.warn(

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import warnings
-from typing import Iterable, overload
 from itertools import chain, zip_longest
+from typing import Iterable, overload
 
 import vapoursynth as vs
 
-from ..exceptions import CustomIndexError
+from ..exceptions import (CustomIndexError, FormatsMismatchError, FramerateMismatchError, LengthMismatchError,
+                          ResolutionsMismatchError, FileNotExistsError)
 from ..functions import check_ref_clip
-from ..types import FrameRangeN, FrameRangesN, T, T0
+from ..types import T0, FrameRangeN, FrameRangesN, T
 
 __all__ = [
     'replace_ranges', 'rfs',
@@ -74,18 +75,35 @@ def replace_ranges(
     if not mismatch:
         check_ref_clip(clip_a, clip_b)
 
+    nranges = normalize_ranges(clip_b, ranges)
+
+    if use_plugin and hasattr(vs.core, 'remap'):
+        try:
+            return vs.core.remap.ReplaceFramesSimple(
+                clip_a, clip_b, mismatch=mismatch,
+                mappings=' '.join(f'[{s} {e + (exclusive if s != e else 0)}]' for s, e in nranges)
+            )
+        except vs.Error as e:
+            msg = str(e).replace('vapoursynth.Error: ReplaceFramesSimple: ', '')
+
+            match msg:
+                case "Clip lengths don't match":
+                    raise LengthMismatchError(replace_ranges, reason=f'({clip_a.num_frames} != {clip_b.num_frames})')
+                case "Clip dimensions don't match":
+                    raise ResolutionsMismatchError(
+                        replace_ranges, reason=f'({clip_a.width}x{clip_a.height} != {clip_b.width}x{clip_b.height})'
+                    )
+                case "Clip formats don't match":
+                    raise FormatsMismatchError(replace_ranges, reason=f'{clip_a.format} != {clip_b.format}')
+                case "Clip frame rates don't match":
+                    raise FramerateMismatchError(replace_ranges, reason=f'{clip_a.fps} != {clip_b.fps}')
+                case "Failed to open the timecodes file.":
+                    raise FileNotExistsError(msg, replace_ranges)
+
     if clip_a.num_frames != clip_b.num_frames:
         warnings.warn(
             f"replace_ranges: 'The number of frames ({clip_a.num_frames} vs. {clip_b.num_frames}) do not match! "
             "The function will still work, but you may run into unintended errors with the output clip!'"
-        )
-
-    nranges = normalize_ranges(clip_b, ranges)
-
-    if use_plugin and hasattr(vs.core, 'remap'):
-        return vs.core.remap.ReplaceFramesSimple(
-            clip_a, clip_b, mismatch=mismatch,
-            mappings=' '.join(f'[{s} {e + (exclusive if s != e else 0)}]' for s, e in nranges)
         )
 
     out = clip_a

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -7,8 +7,8 @@ from typing import Iterable, overload
 import vapoursynth as vs
 
 from ..exceptions import (
-    CustomIndexError, CustomValueError, FileNotExistsError, FormatsMismatchError, FramerateMismatchError,
-    LengthMismatchError, ResolutionsMismatchError
+    CustomIndexError, CustomValueError, FormatsMismatchError, FramerateMismatchError, LengthMismatchError,
+    ResolutionsMismatchError
 )
 from ..functions import check_ref_clip
 from ..types import T0, FrameRangeN, FrameRangesN, T
@@ -90,13 +90,13 @@ def replace_ranges(
 
             match msg:
                 case "Clip lengths don't match":
-                    raise LengthMismatchError(replace_ranges, clip_a, clip_b)
+                    raise LengthMismatchError(replace_ranges, [clip_a, clip_b])
                 case "Clip dimensions don't match":
-                    raise ResolutionsMismatchError(replace_ranges, clip_a, clip_b)
+                    raise ResolutionsMismatchError(replace_ranges, [clip_a, clip_b])
                 case "Clip formats don't match":
-                    raise FormatsMismatchError(replace_ranges, clip_a, clip_b)
+                    raise FormatsMismatchError(replace_ranges, [clip_a, clip_b])
                 case "Clip frame rates don't match":
-                    raise FramerateMismatchError(replace_ranges, clip_a, clip_b)
+                    raise FramerateMismatchError(replace_ranges, [clip_a, clip_b])
                 case _:
                     raise CustomValueError(msg, replace_ranges)
 

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -6,8 +6,10 @@ from typing import Iterable, overload
 
 import vapoursynth as vs
 
-from ..exceptions import (CustomIndexError, FormatsMismatchError, FramerateMismatchError, LengthMismatchError,
-                          ResolutionsMismatchError, FileNotExistsError)
+from ..exceptions import (
+    CustomIndexError, FileNotExistsError, FormatsMismatchError, FramerateMismatchError, LengthMismatchError,
+    ResolutionsMismatchError
+)
 from ..functions import check_ref_clip
 from ..types import T0, FrameRangeN, FrameRangesN, T
 

--- a/vstools/utils/ranges.py
+++ b/vstools/utils/ranges.py
@@ -90,15 +90,13 @@ def replace_ranges(
 
             match msg:
                 case "Clip lengths don't match":
-                    raise LengthMismatchError(replace_ranges, reason=f'({clip_a.num_frames} != {clip_b.num_frames})')
+                    raise LengthMismatchError(clip_a, clip_b, replace_ranges)
                 case "Clip dimensions don't match":
-                    raise ResolutionsMismatchError(
-                        replace_ranges, reason=f'({clip_a.width}x{clip_a.height} != {clip_b.width}x{clip_b.height})'
-                    )
+                    raise ResolutionsMismatchError(clip_a, clip_b, replace_ranges)
                 case "Clip formats don't match":
-                    raise FormatsMismatchError(replace_ranges, reason=f'{clip_a.format} != {clip_b.format}')
+                    raise FormatsMismatchError(clip_a, clip_b, replace_ranges)
                 case "Clip frame rates don't match":
-                    raise FramerateMismatchError(replace_ranges, reason=f'{clip_a.fps} != {clip_b.fps}')
+                    raise FramerateMismatchError(clip_a, clip_b, replace_ranges)
                 case "Failed to open the timecodes file.":
                     raise FileNotExistsError(msg, replace_ranges)
 


### PR DESCRIPTION
This PR adds the following functionality for the function `replace_ranges`:

* Adds a match case that checks the error returned by ReplaceFramesSimple and translates it to a `replace_ranges` error with more useful information.
* Adds additional checks for clip length and framerates which can now be used for ref checking.
* Moves the check for framerates not matching down to after the RFS call. It doesn't really make sense to throw a warning for an operation that will always fail should we use the plugin.