### PR TITLE
Modify transforms

### DIFF
--- a/vstools/utils/colors.py
+++ b/vstools/utils/colors.py
@@ -24,7 +24,7 @@ __all__ = [
     
     'ResampleOPPMawen', 'ResampleOPPMawenSwap',
 
-    'ResampleYCgCoR',
+    'ResampleYCgCo', 'ResampleYCgCoR',
 
     'Colorspace'
 ]
@@ -278,6 +278,19 @@ class ResampleOPPMawenSwap(ResampleRGBMatrixUtil):
     ]
 
 
+class ResampleYCgCo(ResampleRGBMatrixUtil):
+    matrix_rgb2csp = [
+        1 / 4, 1 / 2, 1 / 4,
+        1 / 2, 0, -1 / 2,
+        -1 / 4, 1 / 2, -1 / 4
+    ]
+    matrix_csp2rgb = [
+        1, 1, -1,
+        1, 0, 1,
+        1, -1, -1
+    ]
+
+
 class ResampleYCgCoR(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
         1 / 4, 1 / 2, 1 / 4,
@@ -295,11 +308,12 @@ class Colorspace(CustomIntEnum):
     GRAY = 0
     YUV = 1
     RGB = 2
-    YCgCoR = 3
-    OPP = 4
-    OPP_BM3D = 5
-    OPP_Mawen = 6
-    OPP_Mawen_Swap = 7
+    YCgCo = 3
+    YCgCoR = 4
+    OPP = 5
+    OPP_BM3D = 6
+    OPP_Mawen = 7
+    OPP_Mawen_Swap = 8
 
     @property
     def is_opp(self) -> bool:
@@ -315,6 +329,9 @@ class Colorspace(CustomIntEnum):
 
     @property
     def resampler(self) -> ResampleUtil:
+        if self is self.YCgCo:
+            return ResampleYCgCo()
+        
         if self is self.YCgCoR:
             return ResampleYCgCoR()
 

--- a/vstools/utils/colors.py
+++ b/vstools/utils/colors.py
@@ -21,6 +21,8 @@ __all__ = [
     'ResampleRGB', 'ResampleYUV', 'ResampleGRAY',
 
     'ResampleOPP', 'ResampleOPPBM3D',
+    
+    'ResampleOPPMawen', 'ResampleOPPMawenSwap',
 
     'ResampleYCgCoR',
 
@@ -232,8 +234,8 @@ class ResampleOPP(ResampleRGBMatrixUtil):
     ]
     matrix_csp2rgb = [
         1, 0, -sqrt(2),
-        1, sqrt((3 / 2)), 1 / sqrt(2),
-        1, -sqrt((3 / 2)), 1 / sqrt(2)
+        1, sqrt(3 / 2), 1 / sqrt(2),
+        1, -sqrt(3 / 2), 1 / sqrt(2)
     ]
 
 
@@ -244,9 +246,35 @@ class ResampleOPPBM3D(ResampleRGBMatrixUtil):
         1 / (3 * sqrt(2)), sqrt(2) / -3, 1 / (3 * sqrt(2))
     ]
     matrix_csp2rgb = [
-        1, sqrt((3 / 2)), 1 / sqrt(2),
+        1, sqrt(3 / 2), 1 / sqrt(2),
         1, 0, -sqrt(2),
-        1, -sqrt((3 / 2)), 1 / sqrt(2)
+        1, -sqrt(3 / 2), 1 / sqrt(2)
+    ]
+
+    
+class ResampleOPPMawen(ResampleRGBMatrixUtil):
+    matrix_rgb2csp = [
+        1 / 3, 1 / 3, 1 / 3,
+        1 / 2, 0, -1 / 2,
+        1 / 4, -1 / 2, 1 / 4
+    ]
+    matrix_csp2rgb = [
+        1, 1, 2 / 3,
+        1, 0, -4 / 3,
+        1, -1, 2 / 3
+    ]
+
+    
+class ResampleOPPMawenSwap(ResampleRGBMatrixUtil):
+    matrix_rgb2csp = [
+        1 / 3, 1 / 3, 1 / 3,
+        0, 1 / 2, -1 / 2,
+       -1 / 2, 1 / 4, 1 / 4
+    ]
+    matrix_csp2rgb = [
+        1, 0, -4 / 3,
+        1, 1, 2 / 3,
+        1, -1, 2 / 3
     ]
 
 
@@ -270,6 +298,8 @@ class Colorspace(CustomIntEnum):
     YCgCoR = 3
     OPP = 4
     OPP_BM3D = 5
+    OPP_Mawen = 6
+    OPP_Mawen_Swap = 7
 
     @property
     def is_opp(self) -> bool:
@@ -293,6 +323,12 @@ class Colorspace(CustomIntEnum):
 
         if self is self.OPP_BM3D:
             return ResampleOPPBM3D()
+        
+        if self is self.OPP_Mawen:
+            return ResampleOPPMawen()
+
+        if self is self.OPP_Mawen_Swap:
+            return ResampleOPPMawenSwap()
 
         if self is self.GRAY:
             return ResampleGRAY()

--- a/vstools/utils/colors.py
+++ b/vstools/utils/colors.py
@@ -4,11 +4,9 @@ from typing import Any, ClassVar
 
 import vapoursynth as vs
 
-from vstools.types.builtins import KwargsT
-
 from ..enums import CustomIntEnum
 from ..functions import check_variable_format, depth, plane
-from ..types import FuncExceptT, inject_self
+from ..types import FuncExceptT, KwargsT, inject_self
 from .ranges import interleave_arr
 
 __all__ = [
@@ -20,9 +18,9 @@ __all__ = [
 
     'ResampleRGB', 'ResampleYUV', 'ResampleGRAY',
 
-    'ResampleOPP', 'ResampleOPPBM3D',
-    
-    'ResampleOPPMawen', 'ResampleOPPMawenSwap',
+    'ResampleOPP', 'ResampleOPPLCC',
+
+    'ResampleOPPBM3D', 'ResampleOPPBM3DS',
 
     'ResampleYCgCo', 'ResampleYCgCoR',
 
@@ -239,7 +237,7 @@ class ResampleOPP(ResampleRGBMatrixUtil):
     ]
 
 
-class ResampleOPPBM3D(ResampleRGBMatrixUtil):
+class ResampleOPPLCC(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
         1 / 3, 1 / 3, 1 / 3,
         1 / sqrt(6), 0, -1 / sqrt(6),
@@ -251,8 +249,8 @@ class ResampleOPPBM3D(ResampleRGBMatrixUtil):
         1, -sqrt(3 / 2), 1 / sqrt(2)
     ]
 
-    
-class ResampleOPPMawen(ResampleRGBMatrixUtil):
+
+class ResampleOPPBM3D(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
         1 / 3, 1 / 3, 1 / 3,
         1 / 2, 0, -1 / 2,
@@ -264,12 +262,12 @@ class ResampleOPPMawen(ResampleRGBMatrixUtil):
         1, -1, 2 / 3
     ]
 
-    
-class ResampleOPPMawenSwap(ResampleRGBMatrixUtil):
+
+class ResampleOPPBM3DS(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
         1 / 3, 1 / 3, 1 / 3,
         0, 1 / 2, -1 / 2,
-       -1 / 2, 1 / 4, 1 / 4
+        -1 / 2, 1 / 4, 1 / 4
     ]
     matrix_csp2rgb = [
         1, 0, -4 / 3,
@@ -311,9 +309,9 @@ class Colorspace(CustomIntEnum):
     YCgCo = 3
     YCgCoR = 4
     OPP = 5
-    OPP_BM3D = 6
-    OPP_Mawen = 7
-    OPP_Mawen_Swap = 8
+    OPP_LCC = 6
+    OPP_BM3D = 7
+    OPP_BM3DS = 8
 
     @property
     def is_opp(self) -> bool:
@@ -328,33 +326,25 @@ class Colorspace(CustomIntEnum):
         return 'YUV' in self.name
 
     @property
-    def resampler(self) -> ResampleUtil:
+    def resampler(self) -> type[ResampleUtil]:
         if self is self.YCgCo:
-            return ResampleYCgCo()
-        
-        if self is self.YCgCoR:
-            return ResampleYCgCoR()
-
-        if self is self.OPP:
-            return ResampleOPP()
-
-        if self is self.OPP_BM3D:
-            return ResampleOPPBM3D()
-        
-        if self is self.OPP_Mawen:
-            return ResampleOPPMawen()
-
-        if self is self.OPP_Mawen_Swap:
-            return ResampleOPPMawenSwap()
-
-        if self is self.GRAY:
-            return ResampleGRAY()
-
-        if self is self.YUV:
-            return ResampleYUV()
-
-        if self is self.RGB:
-            return ResampleRGB()
+            return ResampleYCgCo
+        elif self is self.YCgCoR:
+            return ResampleYCgCoR
+        elif self is self.OPP:
+            return ResampleOPP
+        elif self is self.OPP_LCC:
+            return ResampleOPPLCC
+        elif self is self.OPP_BM3D:
+            return ResampleOPPBM3D
+        elif self is self.OPP_BM3DS:
+            return ResampleOPPBM3DS
+        elif self is self.GRAY:
+            return ResampleGRAY
+        elif self is self.YUV:
+            return ResampleYUV
+        elif self is self.RGB:
+            return ResampleRGB
 
         raise NotImplementedError
 

--- a/vstools/utils/colors.py
+++ b/vstools/utils/colors.py
@@ -22,7 +22,7 @@ __all__ = [
 
     'ResampleOPP', 'ResampleOPPBM3D',
 
-    'ResampleYCgCo',
+    'ResampleYCgCoR',
 
     'Colorspace'
 ]
@@ -226,14 +226,14 @@ class ResampleGRAY(ResampleYUV):
 
 class ResampleOPP(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
-        0.2990, 0.5870, 0.1140,
-        0.5000, 0.5000, -1.0000,
-        0.8660, -0.8660, 0.0000
+        1 / 3, 1 / 3, 1 / 3,
+        0, 1 / sqrt(6), -1 / sqrt(6),
+        -sqrt(2) / 3, 1 / (3 * sqrt(2)), 1 / (3 * sqrt(2))
     ]
     matrix_csp2rgb = [
-        1.0000, 0.1140, 0.7436,
-        1.0000, 0.1140, -0.4111,
-        1.0000, -0.8860, 0.1663
+        1, 0, -sqrt(2),
+        1, sqrt((3 / 2)), 1 / sqrt(2),
+        1, -sqrt((3 / 2)), 1 / sqrt(2)
     ]
 
 
@@ -250,7 +250,7 @@ class ResampleOPPBM3D(ResampleRGBMatrixUtil):
     ]
 
 
-class ResampleYCgCo(ResampleRGBMatrixUtil):
+class ResampleYCgCoR(ResampleRGBMatrixUtil):
     matrix_rgb2csp = [
         1 / 4, 1 / 2, 1 / 4,
         1, 0, -1,
@@ -267,7 +267,7 @@ class Colorspace(CustomIntEnum):
     GRAY = 0
     YUV = 1
     RGB = 2
-    YCgCo = 3
+    YCgCoR = 3
     OPP = 4
     OPP_BM3D = 5
 
@@ -285,8 +285,8 @@ class Colorspace(CustomIntEnum):
 
     @property
     def resampler(self) -> ResampleUtil:
-        if self is self.YCgCo:
-            return ResampleYCgCo()
+        if self is self.YCgCoR:
+            return ResampleYCgCoR()
 
         if self is self.OPP:
             return ResampleOPP()


### PR DESCRIPTION
Properly renamed YCgCoR color space, added the original YCgCo color space, added Mawen's BM3D transforms as well as a version with channels swapped that makes it closer to a true OPP color space. Furthermore, the random transform for ResampleOPP that was nearly identical to the BT601 matrix was replaced with an actual OPP color space. 