### PR TITLE
Update initialize_clip

### DIFF
--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -9,7 +9,7 @@ from ..exceptions import (
     UndefinedTransferError, UnsupportedColorRangeError, UnsupportedMatrixError, UnsupportedPrimariesError,
     UnsupportedTransferError
 )
-from ..types import MISSING, FuncExceptT, classproperty
+from ..types import FuncExceptT, classproperty
 from .stubs import PropEnum, _base_from_video, _ColorRangeMeta, _MatrixMeta, _PrimariesMeta, _TransferMeta
 
 __all__ = [

--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -6,7 +6,8 @@ import vapoursynth as vs
 
 from ..exceptions import (
     ReservedMatrixError, ReservedPrimariesError, ReservedTransferError, UndefinedMatrixError, UndefinedPrimariesError,
-    UndefinedTransferError, UnsupportedMatrixError, UnsupportedPrimariesError, UnsupportedTransferError
+    UndefinedTransferError, UnsupportedColorRangeError, UnsupportedMatrixError, UnsupportedPrimariesError,
+    UnsupportedTransferError
 )
 from ..types import MISSING, FuncExceptT, classproperty
 from .stubs import PropEnum, _base_from_video, _ColorRangeMeta, _MatrixMeta, _PrimariesMeta, _TransferMeta
@@ -984,6 +985,12 @@ class ColorRange(_ColorRangeMeta):
     """
 
     @classmethod
+    def from_res(cls, frame: vs.VideoNode | vs.VideoFrame) -> ColorRange:
+        """Guess the color range from the frame resolution."""
+
+        return cls.LIMITED
+
+    @classmethod
     def from_video(
         cls, src: vs.VideoNode | vs.VideoFrame | vs.FrameProps, strict: bool = False, func: FuncExceptT | None = None
     ) -> ColorRange:
@@ -997,9 +1004,7 @@ class ColorRange(_ColorRangeMeta):
         :return:                            ColorRange object.
         """
 
-        from ..utils import get_prop
-
-        return get_prop(src, '_ColorRange', int, ColorRange, MISSING if strict else ColorRange.LIMITED)
+        return _base_from_video(cls, src, UnsupportedColorRangeError, strict, func)
 
     @property
     def value_vs(self) -> int:

--- a/vstools/utils/clips.py
+++ b/vstools/utils/clips.py
@@ -134,12 +134,12 @@ def initialize_clip(
     func = fallback(func, initialize_clip)  # type: ignore
 
     values: list[tuple[type[PropEnum], Any]] = [
-        (Matrix, Matrix.from_param(matrix, func) or Matrix.from_video(clip)),
-        (Transfer, Transfer.from_param(transfer, func) or Transfer.from_video(clip)),
-        (Primaries, Primaries.from_param(primaries, func) or Primaries.from_video(clip)),
-        (ChromaLocation, ChromaLocation.from_param(chroma_location, func) or ChromaLocation.from_video(clip)),
-        (ColorRange, ColorRange.from_param(color_range, func) or ColorRange.from_video(clip)),
-        (FieldBased, FieldBased.from_param(field_based, func) or FieldBased.from_video(clip))
+        (Matrix, matrix),
+        (Transfer, transfer),
+        (Primaries, primaries),
+        (ChromaLocation, chroma_location),
+        (ColorRange, color_range),
+        (FieldBased, field_based)
     ]
 
     clip = PropEnum.ensure_presences(clip, [
@@ -195,20 +195,15 @@ def initialize_input(
     Decorator implementation of ``initialize_clip``
     """
 
-    if function is None:
-        return cast(
-            Callable[[F_VD], F_VD],
-            partial(
-                initialize_input, bits=bits, matrix=matrix, transfer=transfer,
-                primaries=primaries, field_based=field_based, strict=strict, func=func
-            )
-        )
-
     init_args = dict[str, Any](
-        bits=bits, matrix=matrix, transfer=transfer, primaries=primaries,
-        chroma_location=chroma_location, color_range=color_range, field_based=field_based,
-        strict=strict, func=func
+        bits=bits,
+        matrix=matrix, transfer=transfer, primaries=primaries,
+        chroma_location=chroma_location, color_range=color_range,
+        field_based=field_based, strict=strict, func=func
     )
+
+    if function is None:
+        return cast(Callable[[F_VD], F_VD], partial(initialize_input, **init_args))
 
     @wraps(function)
     def _wrapper(*args: Any, **kwargs: Any) -> vs.VideoNode:

--- a/vstools/utils/clips.py
+++ b/vstools/utils/clips.py
@@ -105,6 +105,7 @@ def initialize_clip(
     primaries: PrimariesT | None = None,
     chroma_location: ChromaLocationT | None = None,
     color_range: ColorRangeT | None = None,
+    field_based: FieldBasedT | None = None,
     strict: bool = False, *, func: FuncExceptT | None = None
 ) -> vs.VideoNode:
     """
@@ -122,6 +123,7 @@ def initialize_clip(
                             If no props are set, guess from the video resolution.
     :param color_range:     ColorRange prop to set. If None, tries to get the ColorRange from existing props.
                             If no props are set, assume Limited Range.
+    :param field_based:     FieldBased prop to set. If None, tries to get the FieldBased from existing props.
     :param strict:          Whether to be strict about existing properties.
                             If True, throws an exception if certain frame properties are not found.
     :param func:            Optional function this was called from.
@@ -132,11 +134,12 @@ def initialize_clip(
     func = fallback(func, initialize_clip)  # type: ignore
 
     values: list[tuple[type[PropEnum], Any]] = [
-        (Matrix, Matrix.from_param(matrix, func) or Matrix(clip)),
-        (Transfer, Transfer.from_param(transfer, func) or Transfer(clip)),
-        (Primaries, Primaries.from_param(primaries, func) or Primaries(clip)),
-        (ChromaLocation, ChromaLocation.from_param(chroma_location, func) or ChromaLocation(clip)),
-        (ColorRange, ColorRange.from_param(color_range, func) or ColorRange.LIMITED)
+        (Matrix, Matrix.from_param(matrix, func) or Matrix.from_video(clip)),
+        (Transfer, Transfer.from_param(transfer, func) or Transfer.from_video(clip)),
+        (Primaries, Primaries.from_param(primaries, func) or Primaries.from_video(clip)),
+        (ChromaLocation, ChromaLocation.from_param(chroma_location, func) or ChromaLocation.from_video(clip)),
+        (ColorRange, ColorRange.from_param(color_range, func) or ColorRange.from_video(clip)),
+        (FieldBased, FieldBased.from_param(field_based, func) or FieldBased.from_video(clip))
     ]
 
     clip = PropEnum.ensure_presences(clip, [
@@ -158,6 +161,7 @@ def initialize_input(
     primaries: PrimariesT | None = None,
     chroma_location: ChromaLocationT | None = None,
     color_range: ColorRangeT | None = None,
+    field_based: FieldBasedT | None = None,
     func: FuncExceptT | None = None
 ) -> Callable[[F_VD], F_VD]:
     ...
@@ -171,6 +175,7 @@ def initialize_input(
     primaries: PrimariesT | None = None,
     chroma_location: ChromaLocationT | None = None,
     color_range: ColorRangeT | None = None,
+    field_based: FieldBasedT | None = None,
     strict: bool = False, func: FuncExceptT | None = None
 ) -> F_VD:
     ...
@@ -183,6 +188,7 @@ def initialize_input(
     primaries: PrimariesT | None = None,
     chroma_location: ChromaLocationT | None = None,
     color_range: ColorRangeT | None = None,
+    field_based: FieldBasedT | None = None,
     strict: bool = False, func: FuncExceptT | None = None
 ) -> Callable[[F_VD], F_VD] | F_VD:
     """
@@ -199,12 +205,8 @@ def initialize_input(
         )
 
     init_args = dict[str, Any](
-        bits=bits,
-        matrix=matrix,
-        transfer=transfer,
-        primaries=primaries,
-        chroma_location=chroma_location,
-        color_range=color_range,
+        bits=bits, matrix=matrix, transfer=transfer, primaries=primaries,
+        chroma_location=chroma_location, color_range=color_range, field_based=field_based,
         strict=strict, func=func
     )
 


### PR DESCRIPTION
This function now properly guesses the properties. Before, it would always assume BT709, ChromaLoc=left, and FieldBased=progressive. This did more harm than good on anything that wasn't a modern, 1080p source. It now properly guesses based on the input clip.

I removed FieldBased guessing because, while we could guess TFF/BFF based on the resolution, this is information that indexers will(/should) always provide, and just up 'n changing it will cause more harm than good in cases where we don't have to actually touch it.