### PR TITLE
Match the colorimetry heuristics from mpv

### DIFF
--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -781,12 +781,12 @@ class Primaries(_PrimariesMeta):
 
         fmt, width, height = get_var_infos(frame)
 
-        # Some color primaries are expected to have a certain associated matrix
+        # Some matrices are expected to have a certain associated set of primaries
         # regardless of resolution
-        primaries = Matrix.from_video(frame)
-        matrix = Primaries.from_matrix(primaries)
-        if matrix != Matrix.UNKNOWN:
-            return matrix
+        matrix = Matrix.from_video(frame)
+        primaries = Primaries.from_matrix(matrix)
+        if primaries != Matrix.UNKNOWN:
+            return primaries
 
         if fmt.color_family == vs.RGB:
             return Primaries.BT709


### PR DESCRIPTION
The reasoning behind this being that users may experience unexpected differences in color when using this plugin if its heuristics are not the same as the player they are using, and mpv being both open-source and widely used makes it a good candidate to follow.