### PR TITLE
Fix `FieldBased.field` method check for progressive

### DIFF
--- a/vstools/enums/generic.py
+++ b/vstools/enums/generic.py
@@ -184,7 +184,7 @@ class FieldBased(_FieldBasedMeta):
         :raises UnsupportedFieldBasedError:      PROGRESSIVE value is passed.
         """
 
-        if self.PROGRESSIVE:
+        if self == self.PROGRESSIVE:
             raise UnsupportedFieldBasedError(
                 'Progressive video aren\'t field based!',
                 f'{self.__class__.__name__}.field'


### PR DESCRIPTION
Currently the exception within the branch never gets raised, because `self.PROGRESSIVE` evaluates to `0`.
This change properly checks the value of our `FieldBased` instance against `self.PROGRESSIVE`.