### PR TITLE
Fix `get_h` to return proper value when `ar` is numeric

### DIFF
--- a/vstools/utils/info.py
+++ b/vstools/utils/info.py
@@ -272,7 +272,7 @@ def get_h(width: float, ar_or_ref: vs.VideoNode | vs.VideoFrame | float = 16 / 9
         aspect_ratio = ref.height / ref.width  # type: ignore
         mod = fallback(mod, ref.format.subsampling_h and 2 << ref.format.subsampling_h)  # type: ignore
     else:
-        aspect_ratio = ar_or_ref
+        aspect_ratio = 1 / ar_or_ref
 
         if mod is None:
             mod = 0 if width % 2 else 2


### PR DESCRIPTION
Currently if the `ar` parameter passed to `get_h` is a clip, the function calculates the result properly, but if `ar` is a numeric value, the function fails to take the inverse of the aspect ratio, making it behave as `get_w` would instead.