### PR TITLE
Fix return values in `normalize_ranges` example

### DIFF
--- a/vstools/functions/normalize.py
+++ b/vstools/functions/normalize.py
@@ -210,9 +210,9 @@ def normalize_ranges(clip: vs.VideoNode, ranges: FrameRangeN | FrameRangesN) -> 
         >>> clip.num_frames
         1000
         >>> normalize_ranges(clip, (None, None))
-        [(0, 1000)]
+        [(0, 999)]
         >>> normalize_ranges(clip, (24, -24))
-        [(24, 976)]
+        [(24, 975)]
         >>> normalize_ranges(clip, [(24, 100), (80, 150)])
         [(24, 150)]
 


### PR DESCRIPTION
The ranges are inclusive--this change updates the examples to reflect that.