### PR TITLE
Improve Transfer.from_res selection

### DIFF
--- a/vstools/enums/color.py
+++ b/vstools/enums/color.py
@@ -480,7 +480,13 @@ class Transfer(_TransferMeta):
         if width <= 2048 and height <= 1536:
             return Transfer.BT709
 
-        return Transfer.ST2084
+        if fmt.bits_per_sample == 10:
+            return Transfer.BT2020_10bits
+
+        if fmt.bits_per_sample == 12:
+            return Transfer.BT2020_12bits
+
+        return Transfer.BT709
 
     @classmethod
     def from_video(


### PR DESCRIPTION
SMPTE2084 is not a safe default, as this implies HDR. An HDR source should already have SMPTE2084 along with other HDR metadata set, or else it will look completely washed out. This means that if we have a video with no transfer characteristics set, it is much safer to assume that it is SDR.

Although BT709/1886 and both BT2020 transfers are functionally identical, this change sets the proper BT2020 transfer based on bit depth in order to be technically correct.