### PR TITLE
Change auto-dithering to DitherType.ORDERED and ERROR_DIFFUSION where applicable

### DIFF
--- a/vstools/functions/utils.py
+++ b/vstools/functions/utils.py
@@ -217,7 +217,7 @@ def depth(
     if dither_type is DitherType.AUTO:
         should_dither = DitherType.should_dither(in_fmt, out_fmt, range_in, range_out)
 
-        dither_type = DitherType.ERROR_DIFFUSION if should_dither else DitherType.NONE
+        dither_type = DitherType.ORDERED if should_dither else DitherType.NONE
 
     new_format = in_fmt.replace(
         bits_per_sample=out_fmt.bits_per_sample, sample_type=out_fmt.sample_type

--- a/vstools/utils/clips.py
+++ b/vstools/utils/clips.py
@@ -9,7 +9,7 @@ from ..enums import (
     PrimariesT, PropEnum, Transfer, TransferT
 )
 from ..exceptions import CustomValueError, InvalidColorFamilyError
-from ..functions import check_variable, depth, fallback, get_y, join
+from ..functions import DitherType, check_variable, depth, fallback, get_y, join
 from ..types import F_VD, FuncExceptT, HoldsVideoFormatT, P
 from . import vs_proxy as vs
 from .info import get_depth, get_video_format, get_w
@@ -26,7 +26,8 @@ __all__ = [
 
 
 def finalize_clip(
-    clip: vs.VideoNode, bits: int | None = 10, clamp_tv_range: bool = True, *, func: FuncExceptT | None = None
+    clip: vs.VideoNode, bits: int | None = 10, clamp_tv_range: bool = True,
+    *, dither_type: DitherType = DitherType.ERROR_DIFFUSION, func: FuncExceptT | None = None
 ) -> vs.VideoNode:
     """
     Finalize a clip for output to the encoder.
@@ -42,7 +43,7 @@ def finalize_clip(
     assert check_variable(clip, func or finalize_clip)
 
     if bits:
-        clip = depth(clip, bits)
+        clip = depth(clip, bits, dither_type=dither_type)
     else:
         bits = get_depth(clip)
 


### PR DESCRIPTION
Courtesy of @wiwaz. From our PMs:

@wiwaz:
```
i did tests
at high bitdepths the difference between ordered and error diffusion spatially is unnoticeable
but ordered is static
using error diffusion all the time is hurting our compressability
and maybe even making quality worse
since its adding random temporal noise that we really dont even need
again, the difference is unnoticeable spatially at high depths
ordered only looks ugly when dithered down to 8
so basically when we are doing 32 to 16 or 16 to 10 whatever we should really be considering ordered instead
and opting for error diffusion only for the final dither down
```

With this in mind, this PR is more of a call to action for additional testers to see how well this works out in real-life application. Please test! @NSQY @Setsugennoao